### PR TITLE
修正了 passport-oauth 版本过低的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "main": "./lib/passport-qq",
   "dependencies": {
     "pkginfo": "0.2.x",
-    "passport-oauth": "0.1.x"
+    "passport-oauth": "1.0.0"
   },
   "devDependencies": {
     "vows": "0.6.x"


### PR DESCRIPTION
passport 0.3.0 session初始化相关