### PR TITLE
fix: 不需要hack oauth._get了，不然会有两个clientId传出

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 node_modules
+.idea

--- a/lib/passport-qq/strategy.js
+++ b/lib/passport-qq/strategy.js
@@ -94,6 +94,7 @@ Strategy.prototype.userProfile = function(accessToken, done) {
         var profile = { provider: 'qq' };
         profile.id = result.openid;
         profile.nickname = json.nickname;
+        profile.displayName = json.nickname;
         profile._raw = body;
         profile._json = json;
         done(null, profile);

--- a/lib/passport-qq/strategy.js
+++ b/lib/passport-qq/strategy.js
@@ -95,6 +95,7 @@ Strategy.prototype.userProfile = function(accessToken, done) {
         profile.id = result.openid;
         profile.nickname = json.nickname;
         profile.displayName = json.nickname;
+        profile.photos = [{ value: json.figureurl_qq }];
         profile._raw = body;
         profile._json = json;
         done(null, profile);

--- a/lib/passport-qq/strategy.js
+++ b/lib/passport-qq/strategy.js
@@ -45,7 +45,7 @@
   options.authorizationURL = options.authorizationURL || 'https://graph.qq.com/oauth2.0/authorize';
   options.tokenURL = options.tokenURL || 'https://graph.qq.com/oauth2.0/token';
   options.scopeSeparator = options.scopeSeparator || ',';
-  
+
   OAuth2Strategy.call(this, options, verify);
   this.name = 'qq';
 
@@ -60,15 +60,6 @@
 
     return _request(method, url, headers, post_body, access_token, callback);
   }
-
-  this._oauth2.get = function(url, access_token, callback) {
-    url += (url.indexOf('?') == -1 ? '?' : '&') + (require('querystring')).stringify({
-      access_token: access_token,
-      oauth_consumer_key: this._clientId
-    });
-
-    return this._request('GET', url, {}, '', access_token, callback );
-  };
 }
 
 /**
@@ -92,12 +83,11 @@
  */
 Strategy.prototype.userProfile = function(accessToken, done) {
   var oauth2 = this._oauth2;
-  oauth2.get('https://graph.qq.com/oauth2.0/me', accessToken, function (err, result, res) {
+  oauth2.get(`https://graph.qq.com/oauth2.0/me`, accessToken, function (err, result, res) {
     if (err) { return done(new InternalOAuthError('failed to fetch user profile', err)); }
-    result = JSON.parse(result.substring(result.indexOf('{'), 
+    result = JSON.parse(result.substring(result.indexOf('{'),
                                          result.lastIndexOf('}')+1));
-    oauth2.get('https://graph.qq.com/user/get_user_info?format=json&oauth_consumer_key=' +
-      oauth2._clientId + '&openid=' + result.openid, accessToken, function (err, body, res) {
+    oauth2.get(`https://graph.qq.com/user/get_user_info?format=json&oauth_consumer_key=${oauth2._clientId}&openid=${result.openid}`, accessToken, function (err, body, res) {
       try {
         var json = JSON.parse(body);
 

--- a/lib/passport-qq/strategy.js
+++ b/lib/passport-qq/strategy.js
@@ -83,7 +83,7 @@
  */
 Strategy.prototype.userProfile = function(accessToken, done) {
   var oauth2 = this._oauth2;
-  oauth2.get(`https://graph.qq.com/oauth2.0/me`, accessToken, function (err, result, res) {
+  oauth2.get('https://graph.qq.com/oauth2.0/me', accessToken, function (err, result, res) {
     if (err) { return done(new InternalOAuthError('failed to fetch user profile', err)); }
     result = JSON.parse(result.substring(result.indexOf('{'),
                                          result.lastIndexOf('}')+1));


### PR DESCRIPTION
发现获取到的profile全都是
```json
{
    "msg": "service codec Unmarshal: 1 error(s) decoding:\n\n* oauth_consumer_key expected type uint64, got unconvertible type []string, value: [102493526 102493526]",
    "ret": 1
}
```
跟踪了一下发现get_user_info这步传出了两个oauth_consumer_key，使得url变成了`https://graph.qq.com/user/get_user_info?format=json&oauth_consumer_key=1111111111&openid=<openid>&access_token=<access_token>&oauth_consumer_key=1111111111`